### PR TITLE
Factor out PointerIdentity

### DIFF
--- a/lib/llvm.rb
+++ b/lib/llvm.rb
@@ -9,4 +9,27 @@ module LLVM
     extend ::FFI::Library
     ffi_lib ['LLVM-3.2']
   end
+
+  module PointerIdentity
+    # @private
+    def to_ptr
+      @ptr
+    end
+
+    # Checks if the value is equal to other.
+    def ==(other)
+      other.respond_to?(:to_ptr) &&
+          @ptr == other.to_ptr
+    end
+
+    # Computes hash.
+    def hash
+      @ptr.address.hash
+    end
+
+    # Checks if the value is equivalent to other.
+    def eql?(other)
+      self == other
+    end
+  end
 end

--- a/lib/llvm/core/module.rb
+++ b/lib/llvm/core/module.rb
@@ -1,5 +1,7 @@
 module LLVM
   class Module
+    include PointerIdentity
+
     # @private
     def self.from_ptr(ptr)
       return if ptr.null?
@@ -17,26 +19,6 @@ module LLVM
       return if @ptr.nil?
       C.dispose_module(@ptr)
       @ptr = nil
-    end
-
-    # @private
-    def to_ptr
-      @ptr
-    end
-
-    # Checks if the module is equal to other.
-    def ==(other)
-      case other
-      when LLVM::Module
-        @ptr == other.to_ptr
-      else
-        false
-      end
-    end
-
-    # Checks if the module is equal to other.
-    def eql?(other)
-      other.instance_of?(self.class) && self == other
     end
 
     # Returns a TypeCollection of all the Types in the module.

--- a/lib/llvm/core/value.rb
+++ b/lib/llvm/core/value.rb
@@ -1,35 +1,13 @@
 module LLVM
   class Value
+    include PointerIdentity
+
     # @private
     def self.from_ptr(ptr)
       return if ptr.null?
       val = allocate
       val.instance_variable_set(:@ptr, ptr)
       val
-    end
-
-    # @private
-    def to_ptr
-      @ptr
-    end
-
-    # Checks if the value is equal to other.
-    def ==(other)
-      case other
-      when LLVM::Value
-        @ptr == other.to_ptr
-      else
-        false
-      end
-    end
-
-    def hash
-      @ptr.address.hash
-    end
-
-    # Checks if the value is equal to other.
-    def eql?(other)
-      other.instance_of?(self.class) && self == other
     end
 
     # Returns the Value type. This is abstract and is overidden by its subclasses.

--- a/test/equality_test.rb
+++ b/test/equality_test.rb
@@ -40,7 +40,7 @@ class EqualityTestCase < Test::Unit::TestCase
                       :same      => [int1, int1],
                       :not_same  => [int1, int2, int3, int4],
                       :eql       => [int1, int2],
-                      :not_eql   => [int1, int3, int4]
+                      :not_eql   => [int1, int3]
   end
 
   def test_module
@@ -54,7 +54,7 @@ class EqualityTestCase < Test::Unit::TestCase
                       :same      => [mod1, mod1],
                       :not_same  => [mod1, mod2, mod3, mod4],
                       :eql       => [mod1, mod2],
-                      :not_eql   => [mod1, mod3, mod4]
+                      :not_eql   => [mod1, mod3]
   end
 
   def test_type
@@ -68,7 +68,7 @@ class EqualityTestCase < Test::Unit::TestCase
                       :same      => [type1, type1],
                       :not_same  => [type1, type2, type3, type4],
                       :eql       => [type1, type2],
-                      :not_eql   => [type1, type3, type4]
+                      :not_eql   => [type1, type3]
   end
 
   def test_function
@@ -84,7 +84,7 @@ class EqualityTestCase < Test::Unit::TestCase
                       :same      => [fn1, fn1],
                       :not_same  => [fn1, fn2, fn3, fn4],
                       :eql       => [fn1, fn2],
-                      :not_eql   => [fn1, fn3, fn4]
+                      :not_eql   => [fn1, fn3]
   end
 
 end


### PR DESCRIPTION
This pull request has some backwards-incompatible change in semantics, but I doubt it will be a problem.

Particularly, if someone has subclassed, for example, LLVM::Function, and would be comparing an instance of that class with LLVM::Function with the same @ptr:
- #== returns true,
- #hash returns the same value, but
- #eql? returns false

My change would cause #eql? to return true in this case.

I would say that this doesn't quite make sense, and is very unlikely to be an actual problem. I'm not sure that an ability to subclass LLVM::Stuff is valuable at all.
