### PR TITLE
Homebrew Recipe Name Change

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ A patched formula for LLVM has been created by
 but if you would like to give it a shot, use the following command.
 
 ```bash
-    brew install https://raw.github.com/ruby-llvm/ruby-llvm/650c2636aee00dd17debdf96c03f962f7288bf33/misc/homebrew/llvm-3.2.rb --shared --with-clang
+    brew install https://raw.github.com/ruby-llvm/ruby-llvm/master/misc/homebrew/llvm.rb --shared --with-clang
 ```
 
 See Also

--- a/misc/homebrew/llvm.rb
+++ b/misc/homebrew/llvm.rb
@@ -11,7 +11,7 @@ end
 class Llvm < Formula
   homepage  'http://llvm.org/'
   url       'http://llvm.org/releases/3.2/llvm-3.2.src.tar.gz'
-  sha1      '3ce15bffdca066d8542e011cd1a7e387a134b2d0'
+  sha1      '42d139ab4c9f0c539c60f5ac07486e9d30fc1280'
   head      'http://llvm.org/git/llvm.git'
 
   def patches; DATA; end


### PR DESCRIPTION
It looks like when the homebrew recipe was moved into the ruby-llvm repository it's name was changed. This caused ruby to throw an error that it didn't find the expected class within it when I tried to brew install the recipe from git (as the readme suggested). When I changed the name back, it worked like a champ.
