### PR TITLE
Fix Ruby 2.0 compatibility.

### DIFF
--- a/test/target_test.rb
+++ b/test/target_test.rb
@@ -1,3 +1,5 @@
+# encoding: ascii-8bit
+
 require "test_helper"
 require 'llvm/version'
 require 'llvm/config'
@@ -74,7 +76,7 @@ class TargetTestCase < Test::Unit::TestCase
 
     Tempfile.open('emit') do |tmp|
       assert_nothing_raised { mach.emit(mod, tmp.path, :object) }
-      assert_match %r{\x31\xc0\xc3}o, File.read(tmp.path, mode: 'rb')
+      assert_match %r{\x31\xc0\xc3}, File.read(tmp.path, mode: 'rb')
     end
   end
 


### PR DESCRIPTION
Ruby 2.0 changed the default encoding to UTF-8, which broke a binary regexp
used to check if LLVM actually can emit machine code.
