### PR TITLE
Loosen ffi dependency

### DIFF
--- a/ruby-llvm.gemspec
+++ b/ruby-llvm.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
   s.extensions << 'ext/ruby-llvm-support/Rakefile'
 
-  s.add_dependency             'ffi',      '~> 1.3.1'
+  s.add_dependency             'ffi',      '~> 1.7'
   s.add_development_dependency 'ffi_gen',  '~> 1.1.0'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'simplecov'


### PR DESCRIPTION
Or, was there some particular reason ruby-llvm depends on a minor version of ffi gem?
