### PR TITLE
Fix checking for C++ compiler

### DIFF
--- a/ext/ruby-llvm-support/Rakefile
+++ b/ext/ruby-llvm-support/Rakefile
@@ -42,7 +42,7 @@ end
 
 def find_cxx
   check_for('C++ compiler', %W(clang++ g++), 'CXX') do |cxx|
-    system(cxx, "--version", out: :close, err: :close)
+    system(cxx, "--version")
     $?.success?
   end
 end


### PR DESCRIPTION
I was unable to get the native extension to build. I'm running Mac OS X 10.9.1 (Mavericks) with LLVM 3.4 (via Homebrew) and Clang 5.0 (from Apple). I can run `clang++ --version` from the command line just fine, but the `find_cxx` check was failing. This patch allows my system to successfully find the compiler and build the native extension.
