### PR TITLE
Make GCC the default compiler.

### DIFF
--- a/ext/ruby-llvm-support/Rakefile
+++ b/ext/ruby-llvm-support/Rakefile
@@ -44,7 +44,7 @@ def find_llvm_config
 end
 
 def find_cxx
-  check_for('C++ compiler', %W(clang++ g++), 'CXX') do |cxx|
+  check_for('C++ compiler', %W(g++ clang++), 'CXX') do |cxx|
     system(cxx, "--version")
     $?.success?
   end


### PR DESCRIPTION
Fedora 20's llvm-config currently outputs a flag which causes clang to crash.
