### PR TITLE
Fix MCJITCompiler and tests

### DIFF
--- a/lib/llvm/execution_engine.rb
+++ b/lib/llvm/execution_engine.rb
@@ -84,6 +84,10 @@ module LLVM
       C.get_pointer_to_global(self, global)
     end
 
+    def function_address(name)
+      C.get_function_address(self, name)
+    end
+
     # Returns a ModuleCollection of all the Modules in the engine.
     # @return [ModuleCollection]
     def modules
@@ -192,6 +196,31 @@ module LLVM
       }.merge(options)
 
       super
+    end
+
+    def convert_type(type)
+      case type.kind
+      when :integer
+        if type.width <= 8
+          :int8
+        else
+          "int#{type.width}".to_sym
+        end
+      else
+        type.kind
+      end
+    end
+
+    def run_function(fun, *args)
+      args2 = fun.params.map{|e| convert_type(e.type)}
+      ptr = FFI::Pointer.new(function_address(fun.name))
+      raise "Couldn't find function" if ptr.null?
+
+      return_type = convert_type(fun.function_type.return_type)
+      f = FFI::Function.new(return_type, args2, ptr)
+      ret1 = f.call(*args)
+      ret2 = LLVM.make_generic_value(fun.function_type.return_type, ret1)
+      return ret2
     end
 
     protected

--- a/lib/llvm/execution_engine.rb
+++ b/lib/llvm/execution_engine.rb
@@ -182,7 +182,9 @@ module LLVM
     def initialize(mod, options = {})
       options = {
         :opt_level             => 2, # LLVMCodeGenLevelDefault
-        :code_model            => 0, # LLVMCodeModelDefault
+        # code_model causes segfault with LLVMCodeModelDefault (0) so using
+        # LLVMCodeModelJITDefault (1) instead
+        :code_model            => 1,
         :no_frame_pointer_elim => false,
         :enable_fast_i_sel     => false,
         # TODO

--- a/ruby-llvm.gemspec
+++ b/ruby-llvm.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency             'rake',     '~> 12.0'
   s.add_dependency             'ffi',      '~> 1.9.3'
 
-  s.add_development_dependency 'minitest', '~> 5.3.4'
+  s.add_development_dependency 'minitest', '~> 5.10.1'
   s.add_development_dependency 'minitest-reporters', '~> 1.1.14'
   s.add_development_dependency 'ffi_gen',  '~> 1.2.0'
   s.add_development_dependency 'simplecov'

--- a/test/double_test.rb
+++ b/test/double_test.rb
@@ -20,7 +20,7 @@ class DoubleTestCase < Minitest::Test
       builder.ret(builder.fadd(p0, LLVM::Double(1.0)))
     end
 
-    engine = LLVM::JITCompiler.new(mod)
+    engine = LLVM::MCJITCompiler.new(mod)
 
     arg	= 5.0
     result = engine.run_function(mod.functions["test"], arg)

--- a/test/ipo_test.rb
+++ b/test/ipo_test.rb
@@ -39,7 +39,7 @@ class IPOTestCase < Minitest::Test
     assert fns.include?(main)
 
     # optimize
-    engine = LLVM::JITCompiler.new(mod)
+    engine = LLVM::MCJITCompiler.new(mod)
     passm  = LLVM::PassManager.new(engine)
 
     passm.gdce!


### PR DESCRIPTION
This fixes MCJITCompiler by implementing run_function and fixing the default code_model option. This also updates some of the remaining tests to use MCJITCompiler instead of JITCompiler.

Not strictly related but helpful to me in developing this code was to update some of the dependencies and switching to Minitest::Reporters::SpecReporter.