### PR TITLE
Support libLLVM.so.<version> as used in openSUSE

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -44,6 +44,7 @@ task :generate_ffi do
     FFIGen.generate(
       module_name: 'LLVM::C',
       ffi_lib:     ["libLLVM-#{LLVM::LLVM_VERSION}.so.1",
+                    "libLLVM.so.#{LLVM::LLVM_VERSION}",
                     "LLVM-#{LLVM::LLVM_VERSION}"],
       headers:     headers.map { |header| "llvm-c/#{header}" },
       cflags:      LLVM::CONFIG::CFLAGS.split(/\s/),

--- a/lib/llvm/analysis_ffi.rb
+++ b/lib/llvm/analysis_ffi.rb
@@ -4,7 +4,7 @@ require 'ffi'
 
 module LLVM::C
   extend FFI::Library
-  ffi_lib ["libLLVM-10.so.1", "LLVM-10"]
+  ffi_lib ["libLLVM-10.so.1", "libLLVM.so.10", "LLVM-10"]
 
   def self.attach_function(name, *_)
     begin; super; rescue FFI::NotFoundError => e

--- a/lib/llvm/core/bitcode_ffi.rb
+++ b/lib/llvm/core/bitcode_ffi.rb
@@ -4,7 +4,7 @@ require 'ffi'
 
 module LLVM::C
   extend FFI::Library
-  ffi_lib ["libLLVM-10.so.1", "LLVM-10"]
+  ffi_lib ["libLLVM-10.so.1", "libLLVM.so.10", "LLVM-10"]
 
   def self.attach_function(name, *_)
     begin; super; rescue FFI::NotFoundError => e

--- a/lib/llvm/core_ffi.rb
+++ b/lib/llvm/core_ffi.rb
@@ -4,7 +4,7 @@ require 'ffi'
 
 module LLVM::C
   extend FFI::Library
-  ffi_lib ["libLLVM-10.so.1", "LLVM-10"]
+  ffi_lib ["libLLVM-10.so.1", "libLLVM.so.10", "LLVM-10"]
 
   def self.attach_function(name, *_)
     begin; super; rescue FFI::NotFoundError => e

--- a/lib/llvm/execution_engine_ffi.rb
+++ b/lib/llvm/execution_engine_ffi.rb
@@ -4,7 +4,7 @@ require 'ffi'
 
 module LLVM::C
   extend FFI::Library
-  ffi_lib ["libLLVM-10.so.1", "LLVM-10"]
+  ffi_lib ["libLLVM-10.so.1", "libLLVM.so.10", "LLVM-10"]
 
   def self.attach_function(name, *_)
     begin; super; rescue FFI::NotFoundError => e

--- a/lib/llvm/linker_ffi.rb
+++ b/lib/llvm/linker_ffi.rb
@@ -4,7 +4,7 @@ require 'ffi'
 
 module LLVM::C
   extend FFI::Library
-  ffi_lib ["libLLVM-10.so.1", "LLVM-10"]
+  ffi_lib ["libLLVM-10.so.1", "libLLVM.so.10", "LLVM-10"]
 
   def self.attach_function(name, *_)
     begin; super; rescue FFI::NotFoundError => e

--- a/lib/llvm/target_ffi.rb
+++ b/lib/llvm/target_ffi.rb
@@ -4,7 +4,7 @@ require 'ffi'
 
 module LLVM::C
   extend FFI::Library
-  ffi_lib ["libLLVM-10.so.1", "LLVM-10"]
+  ffi_lib ["libLLVM-10.so.1", "libLLVM.so.10", "LLVM-10"]
 
   def self.attach_function(name, *_)
     begin; super; rescue FFI::NotFoundError => e

--- a/lib/llvm/transforms/builder_ffi.rb
+++ b/lib/llvm/transforms/builder_ffi.rb
@@ -4,7 +4,7 @@ require 'ffi'
 
 module LLVM::C
   extend FFI::Library
-  ffi_lib ["libLLVM-10.so.1", "LLVM-10"]
+  ffi_lib ["libLLVM-10.so.1", "libLLVM.so.10", "LLVM-10"]
 
   def self.attach_function(name, *_)
     begin; super; rescue FFI::NotFoundError => e

--- a/lib/llvm/transforms/ipo_ffi.rb
+++ b/lib/llvm/transforms/ipo_ffi.rb
@@ -4,7 +4,7 @@ require 'ffi'
 
 module LLVM::C
   extend FFI::Library
-  ffi_lib ["libLLVM-10.so.1", "LLVM-10"]
+  ffi_lib ["libLLVM-10.so.1", "libLLVM.so.10", "LLVM-10"]
 
   def self.attach_function(name, *_)
     begin; super; rescue FFI::NotFoundError => e

--- a/lib/llvm/transforms/scalar_ffi.rb
+++ b/lib/llvm/transforms/scalar_ffi.rb
@@ -4,7 +4,7 @@ require 'ffi'
 
 module LLVM::C
   extend FFI::Library
-  ffi_lib ["libLLVM-10.so.1", "LLVM-10"]
+  ffi_lib ["libLLVM-10.so.1", "libLLVM.so.10", "LLVM-10"]
 
   def self.attach_function(name, *_)
     begin; super; rescue FFI::NotFoundError => e

--- a/lib/llvm/transforms/vectorize_ffi.rb
+++ b/lib/llvm/transforms/vectorize_ffi.rb
@@ -4,7 +4,7 @@ require 'ffi'
 
 module LLVM::C
   extend FFI::Library
-  ffi_lib ["libLLVM-10.so.1", "LLVM-10"]
+  ffi_lib ["libLLVM-10.so.1", "libLLVM.so.10", "LLVM-10"]
 
   def self.attach_function(name, *_)
     begin; super; rescue FFI::NotFoundError => e


### PR DESCRIPTION
openSUSE installs the LLVM library in `/usr/lib64/libLLVM.so.$VERSION`, which this PR adds to the search list for `lib_ffi`.