### PR TITLE
Pass Manager add, remove, and fix passes to LLVM-C 15 parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,38 @@
 ## [Unreleased]
 ### Changed
 ### Added
+- Tests for adding pass manager passes - catches pass removals and certain bugs
+- Additional documentation for passes
+- Missing passes:
+  - dce!
+  - bdce!
+  - scalarizer!
+  - mldst_motion!
+  - new_gvn!
+  - instsimplify!
+  - loop_reroll!
+  - loop_unroll_and_jam!
+  - loweratomic!
+  - partially_inline_libcalls!
+  - verify!
+  - early_cse_memssa!
+  - scoped_noalias_aa!
+  - lower_constant_intrinsics!
+  - mergereturn!
+  - lowerswitch!
+  - add_discriminators!
+  - called_value_propagation!
+- Warnings on removed passes:
+  - arg_promote!
+  - ipcp! 
+  - loop_unswitch! 
+  - simplify_libcalls! 
+  - constprop! 
+  - bb_vectorize!
+- Bug fixes for passes:
+  - dae!
+  - internalize!
+  - scalarrepl_threshold!
 
 ## [15.0.2] - 2022-01-30
 ### Changed

--- a/lib/llvm/core/pass_manager.rb
+++ b/lib/llvm/core/pass_manager.rb
@@ -1,5 +1,10 @@
 # frozen_string_literal: true
 
+require "llvm/transforms/ipo"
+require "llvm/transforms/scalar"
+require "llvm/transforms/utils"
+require "llvm/transforms/vectorize"
+
 module LLVM
   # The PassManager runs a queue of passes on a module. See
   # http://llvm.org/docs/Passes.html for the list of available passes.

--- a/lib/llvm/transforms/ipo.rb
+++ b/lib/llvm/transforms/ipo.rb
@@ -9,72 +9,116 @@ module LLVM
   class PassManager
     # @LLVMpass arg_promotion
     def arg_promote!
-      C.add_argument_promotion_pass(self)
+      warn('arg_promote! / LLVMAddArgumentPromotionPass was removed from LLVM')
     end
 
     # @LLVMpass const_merge
+    # /** See llvm::createConstantMergePass function. */
+    # void LLVMAddConstantMergePass(LLVMPassManagerRef PM);
     def const_merge!
       C.add_constant_merge_pass(self)
     end
 
+    # @LLVMpass mergefunc
+    # /** See llvm::createMergeFunctionsPass function. */
+    # void LLVMAddMergeFunctionsPass(LLVMPassManagerRef PM);
+    def mergefunc!
+      C.add_merge_functions_pass(self)
+    end
+
+    # @LLVMpass called-value-propagation
+    # /** See llvm::createCalledValuePropagationPass function. */
+    # void LLVMAddCalledValuePropagationPass(LLVMPassManagerRef PM);
+    def called_value_propagation!
+      C.add_called_value_propagation_pass(self)
+    end
+
     # @LLVMpass dae
+    # /** See llvm::createDeadArgEliminationPass function. */
+    # void LLVMAddDeadArgEliminationPass(LLVMPassManagerRef PM);
     def dae!
-      C.add_dead_arg_elimination(self)
+      C.add_dead_arg_elimination_pass(self)
     end
 
     # @LLVMpass function_attrs
+    # /** See llvm::createFunctionAttrsPass function. */
+    # void LLVMAddFunctionAttrsPass(LLVMPassManagerRef PM);
     def fun_attrs!
       C.add_function_attrs_pass(self)
     end
 
     # @LLVMpass inline
+    # /** See llvm::createFunctionInliningPass function. */
+    # void LLVMAddFunctionInliningPass(LLVMPassManagerRef PM);
     def inline!
       C.add_function_inlining_pass(self)
     end
 
     # @LLVMpass always_inline
+    # /** See llvm::createAlwaysInlinerPass function. */
+    # void LLVMAddAlwaysInlinerPass(LLVMPassManagerRef PM);
     def always_inline!
       C.add_always_inliner_pass(self)
     end
 
     # @LLVMpass gdce
+    # /** See llvm::createGlobalDCEPass function. */
+    # void LLVMAddGlobalDCEPass(LLVMPassManagerRef PM);
     def gdce!
       C.add_global_dce_pass(self)
     end
 
     # @LLVMpass global_opt
+    # /** See llvm::createGlobalOptimizerPass function. */
+    # void LLVMAddGlobalOptimizerPass(LLVMPassManagerRef PM);
     def global_opt!
       C.add_global_optimizer_pass(self)
     end
 
     # @LLVMpass ipcp
     def ipcp!
-      C.add_ip_constant_propagation_pass(self)
+      warn('ipcp! / LLVMAddIPConstantPropagationPass was removed from LLVM')
     end
 
     # @LLVMpass prune_eh
+    # /** See llvm::createPruneEHPass function. */
+    # void LLVMAddPruneEHPass(LLVMPassManagerRef PM);
     def prune_eh!
       C.add_prune_eh_pass(self)
     end
 
     # @LLVMpass ipsccp
+    # /** See llvm::createIPSCCPPass function. */
+    # void LLVMAddIPSCCPPass(LLVMPassManagerRef PM);
     def ipsccp!
       C.add_ipsccp_pass(self)
     end
 
     # @LLVMpass internalize
+    # /** See llvm::createInternalizePass function. */
+    # void LLVMAddInternalizePass(LLVMPassManagerRef, unsigned AllButMain);
     def internalize!(all_but_main = true)
-      C.add_internalize_pass(self, all_but_main)
+      C.add_internalize_pass(self, all_but_main ? 1 : 0)
     end
 
     # @LLVMpass sdp
+    # /** See llvm::createStripDeadPrototypesPass function. */
+    # void LLVMAddStripDeadPrototypesPass(LLVMPassManagerRef PM);
     def sdp!
       C.add_strip_dead_prototypes_pass(self)
     end
 
     # @LLVMpass strip
+    # /** See llvm::createStripSymbolsPass function. */
+    # void LLVMAddStripSymbolsPass(LLVMPassManagerRef PM);
     def strip!
       C.add_strip_symbols_pass(self)
     end
+
+  end
+
+  module C
+    attach_function :add_merge_functions_pass, :LLVMAddMergeFunctionsPass, [:pointer], :void
+    attach_function :add_called_value_propagation_pass, :LLVMAddCalledValuePropagationPass, [:pointer], :void
   end
 end

--- a/lib/llvm/transforms/ipo_ffi.rb
+++ b/lib/llvm/transforms/ipo_ffi.rb
@@ -12,14 +12,6 @@ module LLVM::C
     end
   end
 
-  # See llvm::createArgumentPromotionPass function.
-  #
-  # @method add_argument_promotion_pass(pm)
-  # @param [FFI::Pointer(PassManagerRef)] pm
-  # @return [nil]
-  # @scope class
-  attach_function :add_argument_promotion_pass, :LLVMAddArgumentPromotionPass, [:pointer], :void
-
   # See llvm::createConstantMergePass function.
   #
   # @method add_constant_merge_pass(pm)
@@ -75,14 +67,6 @@ module LLVM::C
   # @return [nil]
   # @scope class
   attach_function :add_global_optimizer_pass, :LLVMAddGlobalOptimizerPass, [:pointer], :void
-
-  # See llvm::createIPConstantPropagationPass function.
-  #
-  # @method add_ip_constant_propagation_pass(pm)
-  # @param [FFI::Pointer(PassManagerRef)] pm
-  # @return [nil]
-  # @scope class
-  attach_function :add_ip_constant_propagation_pass, :LLVMAddIPConstantPropagationPass, [:pointer], :void
 
   # See llvm::createPruneEHPass function.
   #

--- a/lib/llvm/transforms/scalar.rb
+++ b/lib/llvm/transforms/scalar.rb
@@ -7,158 +7,320 @@ require 'llvm/transforms/scalar_ffi'
 module LLVM
   class PassManager
     # @LLVMpass adce
+    # /** See llvm::createAggressiveDCEPass function. */
+    # void LLVMAddAggressiveDCEPass(LLVMPassManagerRef PM);
     def adce!
       C.add_aggressive_dce_pass(self)
     end
 
+    # @LLVMpass dce
+    # /** See llvm::createDeadCodeEliminationPass function. */
+    # void LLVMAddDCEPass(LLVMPassManagerRef PM);
+    def dce!
+      C.add_dce_pass(self)
+    end
+
+    # @LLVMpass bdce
+    # /** See llvm::createBitTrackingDCEPass function. */
+    # void LLVMAddBitTrackingDCEPass(LLVMPassManagerRef PM);
+    def bdce!
+      C.add_bit_tracking_dce_pass(self)
+    end
+
+    # @LLVMpass alignment_from_assumptions
+    # /** See llvm::createAlignmentFromAssumptionsPass function. */
+    # void LLVMAddAlignmentFromAssumptionsPass(LLVMPassManagerRef PM);
+    def alignment_from_assumptions!
+      C.add_alignment_from_assumptions_pass(self)
+    end
+
     # @LLVMpass simplifycfg
+    # /** See llvm::createCFGSimplificationPass function. */
+    # void LLVMAddCFGSimplificationPass(LLVMPassManagerRef PM);
     def simplifycfg!
       C.add_cfg_simplification_pass(self)
     end
 
     # @LLVMpass dse
+    # /** See llvm::createDeadStoreEliminationPass function. */
+    # void LLVMAddDeadStoreEliminationPass(LLVMPassManagerRef PM);
     def dse!
       C.add_dead_store_elimination_pass(self)
     end
 
+    # @LLVMPass scalarizer
+    # /** See llvm::createScalarizerPass function. */
+    # void LLVMAddScalarizerPass(LLVMPassManagerRef PM);
+    def scalarizer!
+      C.add_scalarizer_pass(self)
+    end
+
+    # @LLVMpass mldst-motion
+    # /** See llvm::createMergedLoadStoreMotionPass function. */
+    # void LLVMAddMergedLoadStoreMotionPass(LLVMPassManagerRef PM);
+    def mldst_motion!
+      C.add_merged_load_store_motion_pass(self)
+    end
+
     # @LLVMpass gvn
+    # /** See llvm::createGVNPass function. */
+    # void LLVMAddGVNPass(LLVMPassManagerRef PM);
     def gvn!
       C.add_gvn_pass(self)
     end
 
+    # @LLVMpass newgvn
+    # /** See llvm::createGVNPass function. */
+    # void LLVMAddNewGVNPass(LLVMPassManagerRef PM);
+    def newgvn!
+      C.add_new_gvn_pass(self)
+    end
+
     # @LLVMpass indvars
+    # /** See llvm::createIndVarSimplifyPass function. */
+    # void LLVMAddIndVarSimplifyPass(LLVMPassManagerRef PM);
     def indvars!
       C.add_ind_var_simplify_pass(self)
     end
 
     # @LLVMpass instcombine
+    # /** See llvm::createInstructionCombiningPass function. */
+    # void LLVMAddInstructionCombiningPass(LLVMPassManagerRef PM);
     def instcombine!
       C.add_instruction_combining_pass(self)
     end
 
+    # @LLVMpass instsimplify
+    # /** See llvm::createInstSimplifyLegacyPass function. */
+    # void LLVMAddInstructionSimplifyPass(LLVMPassManagerRef PM);
+    def instsimplify!
+      C.add_instruction_simplify_pass(self)
+    end
+
     # @LLVMpass jump-threading
+    # /** See llvm::createJumpThreadingPass function. */
+    # void LLVMAddJumpThreadingPass(LLVMPassManagerRef PM);
     def jump_threading!
       C.add_jump_threading_pass(self)
     end
 
     # @LLVMpass licm
+    # /** See llvm::createLICMPass function. */
+    # void LLVMAddLICMPass(LLVMPassManagerRef PM);
     def licm!
       C.add_licm_pass(self)
     end
 
     # @LLVMpass loop-deletion
+    # /** See llvm::createLoopDeletionPass function. */
+    # void LLVMAddLoopDeletionPass(LLVMPassManagerRef PM);
     def loop_deletion!
       C.add_loop_deletion_pass(self)
     end
 
     # @LLVMpass loop-idiom
+    # /** See llvm::createLoopIdiomPass function */
+    # void LLVMAddLoopIdiomPass(LLVMPassManagerRef PM);
     def loop_idiom!
       C.add_loop_idiom_pass(self)
     end
 
     # @LLVMpass loop-rotate
+    # /** See llvm::createLoopRotatePass function. */
+    # void LLVMAddLoopRotatePass(LLVMPassManagerRef PM);
     def loop_rotate!
       C.add_loop_rotate_pass(self)
     end
 
+    # @LLVMpass loop-reroll
+    # /** See llvm::createLoopRerollPass function. */
+    # void LLVMAddLoopRerollPass(LLVMPassManagerRef PM);
+    def loop_reroll!
+      C.add_loop_reroll_pass(self)
+    end
+
     # @LLVMpass loop-unroll
+    #     /** See llvm::createLoopUnrollPass function. */
+    #     void LLVMAddLoopUnrollPass(LLVMPassManagerRef PM);
     def loop_unroll!
       C.add_loop_unroll_pass(self)
     end
 
+    # @LLVMpass loop-unroll-and-jam
+    # /** See llvm::createLoopUnrollAndJamPass function. */
+    # void LLVMAddLoopUnrollAndJamPass(LLVMPassManagerRef PM);
+    def loop_unroll_and_jam!
+      C.add_loop_unroll_and_jam_pass(self)
+    end
+
     # @LLVMpass loop-unswitch
     def loop_unswitch!
-      C.add_loop_unswitch_pass(self)
+      warn('loop_unswitch! / LLVMAddLoopUnswitchPass was removed in LLVM 15')
+    end
+
+    # @LLVMpass loweratomic
+    # /** See llvm::createLowerAtomicPass function. */
+    # void LLVMAddLowerAtomicPass(LLVMPassManagerRef PM);
+    def loweratomic!
+      C.add_lower_atomic_pass(self)
     end
 
     # @LLVMpass memcpyopt
+    # /** See llvm::createMemCpyOptPass function. */
+    # void LLVMAddMemCpyOptPass(LLVMPassManagerRef PM);
     def memcpyopt!
       C.add_mem_cpy_opt_pass(self)
     end
 
-    # @LLVMpass mem2reg
-    def mem2reg!
-      C.add_promote_memory_to_register_pass(self)
+    # @LLVMpass partially-inline-libcalls
+    # /** See llvm::createPartiallyInlineLibCallsPass function. */
+    # void LLVMAddPartiallyInlineLibCallsPass(LLVMPassManagerRef PM);
+    def partially_inline_libcalls!
+      C.add_partially_inline_lib_calls_pass(self)
     end
 
     # @LLVMpass reassociate
+    # /** See llvm::createReassociatePass function. */
+    # void LLVMAddReassociatePass(LLVMPassManagerRef PM);
     def reassociate!
       C.add_reassociate_pass(self)
     end
 
     # @LLVMpass sccp
+    # /** See llvm::createSCCPPass function. */
+    # void LLVMAddSCCPPass(LLVMPassManagerRef PM);
     def sccp!
       C.add_sccp_pass(self)
     end
 
-    # @LLVMpass scalarrepl
+    # @LLVMpass sroa
+    # /** See llvm::createSROAPass function. */
+    # void LLVMAddScalarReplAggregatesPass(LLVMPassManagerRef PM);
     def scalarrepl!
       C.add_scalar_repl_aggregates_pass(self)
     end
 
-    # @LLVMpass scalarrepl
+    # @LLVMpass sroa
+    # /** See llvm::createSROAPass function. */
+    # void LLVMAddScalarReplAggregatesPassSSA(LLVMPassManagerRef PM);
     def scalarrepl_ssa!
       C.add_scalar_repl_aggregates_pass_ssa(self)
     end
 
-    # @LLVMpass scalarrepl
-    def scalarrepl_threshold!(threshold)
-      C.add_scalar_repl_aggregates_pass(self, threshold)
+    # @LLVMpass sroa
+    # /** See llvm::createSROAPass function. */
+    # void LLVMAddScalarReplAggregatesPassWithThreshold(LLVMPassManagerRef PM,
+    #                                                   int Threshold);
+    # threshold appears unused: https://llvm.org/doxygen/Scalar_8cpp_source.html#l00211
+    def scalarrepl_threshold!(threshold = 0)
+      C.add_scalar_repl_aggregates_pass_with_threshold(self, threshold)
     end
 
     # @LLVMpass simplify-libcalls
+    # /** See llvm::createSimplifyLibCallsPass function. */
+    # void LLVMAddSimplifyLibCallsPass(LLVMPassManagerRef PM);
+    # removed: https://llvm.org/doxygen/Scalar_8cpp_source.html#l00211
     def simplify_libcalls!
-      C.add_simplify_lib_calls_pass(self)
+      warn('simplify_libcalls! / LLVMAddSimplifyLibCallsPass was removed from LLVM')
     end
 
     # @LLVMpass tailcallelim
+    # /** See llvm::createTailCallEliminationPass function. */
+    # void LLVMAddTailCallEliminationPass(LLVMPassManagerRef PM);
     def tailcallelim!
       C.add_tail_call_elimination_pass(self)
     end
 
     # @LLVMpass constprop
     def constprop!
-      C.add_constant_propagation_pass(self)
+      warn('constprop! / LLVMAddConstantPropagationPass was removed from LLVM')
     end
 
     # @LLVMpass reg2mem
+    # /** See llvm::demotePromoteMemoryToRegisterPass function. */
+    # void LLVMAddDemoteMemoryToRegisterPass(LLVMPassManagerRef PM);
     def reg2mem!
       C.add_demote_memory_to_register_pass(self)
     end
 
+    # @LLVMpass verify
+    # /** See llvm::createVerifierPass function. */
+    # void LLVMAddVerifierPass(LLVMPassManagerRef PM);
+    def verify!
+      C.add_verifier_pass(self)
+    end
+
     # @LLVMpass cvprop
+    # /** See llvm::createCorrelatedValuePropagationPass function */
+    # void LLVMAddCorrelatedValuePropagationPass(LLVMPassManagerRef PM);
     def cvprop!
       C.add_correlated_value_propagation_pass(self)
     end
 
     # @LLVMpass early-cse
+    # /** See llvm::createEarlyCSEPass function */
+    # void LLVMAddEarlyCSEPass(LLVMPassManagerRef PM);
     def early_cse!
       C.add_early_cse_pass(self)
     end
 
+    # @LLVMpass early-cse-memssa
+    # /** See llvm::createEarlyCSEPass function */
+    # void LLVMAddEarlyCSEMemSSAPass(LLVMPassManagerRef PM);
+    def early_cse_memssa!
+      C.add_early_cse_mem_ssa_pass(self)
+    end
+
     # @LLVMpass lower-expect
+    # /** See llvm::createLowerExpectIntrinsicPass function */
+    # void LLVMAddLowerExpectIntrinsicPass(LLVMPassManagerRef PM);
     def lower_expect!
       C.add_lower_expect_intrinsic_pass(self)
     end
 
+    # @LLVMPass lower-constant-intrinsics
+    # /** See llvm::createLowerConstantIntrinsicsPass function */
+    # void LLVMAddLowerConstantIntrinsicsPass(LLVMPassManagerRef PM);
+    def lower_constant_intrinsics!
+      C.add_lower_constant_intrinsics_pass(self)
+    end
+
     # @LLVMpass tbaa
+    # /** See llvm::createTypeBasedAliasAnalysisPass function */
+    # void LLVMAddTypeBasedAliasAnalysisPass(LLVMPassManagerRef PM);
     def tbaa!
       C.add_type_based_alias_analysis_pass(self)
     end
 
+    # @ LLVMPass scoped-noalias-aa
+    # /** See llvm::createScopedNoAliasAAPass function */
+    # void LLVMAddScopedNoAliasAAPass(LLVMPassManagerRef PM);
+    def scoped_noalias_aa!
+      C.add_scoped_no_alias_aa_pass(self)
+    end
+
     # @LLVMpass basicaa
+    # /** See llvm::createBasicAliasAnalysisPass function */
+    # void LLVMAddBasicAliasAnalysisPass(LLVMPassManagerRef PM);
     def basicaa!
       C.add_basic_alias_analysis_pass(self)
     end
 
-    # @LLVMpass mergefunc
-    def mergefunc!
-      C.add_merge_functions_pass(self)
+    # @LLVMpass mergereturn
+    # /** See llvm::createUnifyFunctionExitNodesPass function */
+    # void LLVMAddUnifyFunctionExitNodesPass(LLVMPassManagerRef PM);
+    def mergereturn!
+      C.add_unify_function_exit_nodes_pass(self)
     end
 
   end
 
   module C
-    attach_function :add_merge_functions_pass, :LLVMAddMergeFunctionsPass, [:pointer], :void
+    attach_function :add_dce_pass, :LLVMAddDCEPass, [:pointer], :void
+    attach_function :add_instruction_simplify_pass, :LLVMAddInstructionSimplifyPass, [:pointer], :void
+    attach_function :add_loop_unroll_and_jam_pass, :LLVMAddLoopUnrollAndJamPass, [:pointer], :void
+    attach_function :add_lower_atomic_pass, :LLVMAddLowerAtomicPass, [:pointer], :void
+    attach_function :add_lower_constant_intrinsics_pass, :LLVMAddLowerConstantIntrinsicsPass, [:pointer], :void
+    attach_function :add_unify_function_exit_nodes_pass, :LLVMAddUnifyFunctionExitNodesPass, [:pointer], :void
   end
 end

--- a/lib/llvm/transforms/scalar_ffi.rb
+++ b/lib/llvm/transforms/scalar_ffi.rb
@@ -164,14 +164,6 @@ module LLVM::C
   # @scope class
   attach_function :add_loop_unroll_pass, :LLVMAddLoopUnrollPass, [:pointer], :void
 
-  # See llvm::createLoopUnswitchPass function.
-  #
-  # @method add_loop_unswitch_pass(pm)
-  # @param [FFI::Pointer(PassManagerRef)] pm
-  # @return [nil]
-  # @scope class
-  attach_function :add_loop_unswitch_pass, :LLVMAddLoopUnswitchPass, [:pointer], :void
-
   # See llvm::createMemCpyOptPass function.
   #
   # @method add_mem_cpy_opt_pass(pm)
@@ -245,14 +237,6 @@ module LLVM::C
   # @scope class
   attach_function :add_scalar_repl_aggregates_pass_with_threshold, :LLVMAddScalarReplAggregatesPassWithThreshold, [:pointer, :int], :void
 
-  # See llvm::createSimplifyLibCallsPass function.
-  #
-  # @method add_simplify_lib_calls_pass(pm)
-  # @param [FFI::Pointer(PassManagerRef)] pm
-  # @return [nil]
-  # @scope class
-  attach_function :add_simplify_lib_calls_pass, :LLVMAddSimplifyLibCallsPass, [:pointer], :void
-
   # See llvm::createTailCallEliminationPass function.
   #
   # @method add_tail_call_elimination_pass(pm)
@@ -260,14 +244,6 @@ module LLVM::C
   # @return [nil]
   # @scope class
   attach_function :add_tail_call_elimination_pass, :LLVMAddTailCallEliminationPass, [:pointer], :void
-
-  # See llvm::createConstantPropagationPass function.
-  #
-  # @method add_constant_propagation_pass(pm)
-  # @param [FFI::Pointer(PassManagerRef)] pm
-  # @return [nil]
-  # @scope class
-  attach_function :add_constant_propagation_pass, :LLVMAddConstantPropagationPass, [:pointer], :void
 
   # See llvm::demotePromoteMemoryToRegisterPass function.
   #

--- a/lib/llvm/transforms/utils.rb
+++ b/lib/llvm/transforms/utils.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'llvm'
+require 'llvm/core'
+
+module LLVM
+  class PassManager
+
+    # @LLVMpass lowerswitch
+    # /** See llvm::createLowerSwitchPass function. */
+    # void LLVMAddLowerSwitchPass(LLVMPassManagerRef PM);
+    def lowerswitch!
+      C.add_lower_switch_pass(self)
+    end
+
+    # @LLVMpass mem2reg
+    # /** See llvm::createPromoteMemoryToRegisterPass function. */
+    # void LLVMAddPromoteMemoryToRegisterPass(LLVMPassManagerRef PM);
+    def mem2reg!
+      C.add_promote_memory_to_register_pass(self)
+    end
+
+    # @LLVMpass add-discriminators
+    # /** See llvm::createAddDiscriminatorsPass function. */
+    # void LLVMAddAddDiscriminatorsPass(LLVMPassManagerRef PM);
+    def add_discriminators!
+      C.add_add_discriminators_pass(self)
+    end
+  end
+
+  module C
+    attach_function :add_add_discriminators_pass, :LLVMAddAddDiscriminatorsPass, [:pointer], :void
+  end
+end

--- a/lib/llvm/transforms/vectorize.rb
+++ b/lib/llvm/transforms/vectorize.rb
@@ -8,15 +8,20 @@ module LLVM
   class PassManager
     # @LLVMpass bb_vectorize
     def bb_vectorize!
-      C.add_bb_vectorize_pass(self)
+      warn('bb_vectorize! / LLVMAddBBVectorizePass was removed from LLVM - replace with slp_vectorize!')
+      slp_vectorize!
     end
 
     # @LLVMpass loop_vectorize
+    # /** See llvm::createLoopVectorizePass function. */
+    # void LLVMAddLoopVectorizePass(LLVMPassManagerRef PM);
     def loop_vectorize!
       C.add_loop_vectorize_pass(self)
     end
 
     # @LLVMpass slp_vectorize
+    # /** See llvm::createSLPVectorizerPass function. */
+    # void LLVMAddSLPVectorizePass(LLVMPassManagerRef PM);
     def slp_vectorize!
       C.add_slp_vectorize_pass(self)
     end

--- a/test/pass_manager_builder_test.rb
+++ b/test/pass_manager_builder_test.rb
@@ -53,13 +53,7 @@ class PassManagerBuilderTest < Minitest::Test
     end
   end
 
-  PASSES = [
-    'always_inline!',
-    'adce!',
-    'tailcallelim!',
-    'fun_attrs!',
-    'mergefunc!',
-  ].freeze
+  PASSES = LLVM::PassManager.new.methods.grep(/\S!$/).freeze
 
   describe "PassManager Passes" do
     before do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -27,7 +27,6 @@ end
 
 require "llvm/core"
 require "llvm/execution_engine"
-require "llvm/transforms/scalar"
 
 class Minitest::Test
 


### PR DESCRIPTION
Fix some accumulated cruft on passes.

- [x] Add warnings for removed passes: `arg_promote!` `ipcp!` `loop_unswitch!` `simplify_libcalls!` `constprop!` `bb_vectorize!`
- [x] Fix broken `dae!`
- [x] Fix broken `internalize!`
- [x] Fix broken `scalarrepl_threshold!`
- [X] Add tests for passes

## New Scalar Passes
- [X] dce!
- [X] bdce!
- [X] scalarizer!
- [X] mldst_motion!
- [X] new_gvn!
- [X] instsimplify!
- [X] loop_reroll!
- [X] loop_unroll_and_jam!
- [X] loweratomic!
- [X] partially_inline_libcalls!
- [X] verify!
- [X] early_cse_memssa!
- [X] scoped_noalias_aa!
- [X] lower_constant_intrinsics!
- [X] mergereturn!

## New Utils Passes
- [X] lowerswitch!
- [X] add_discriminators!

## New IPO Passes
- [X] called_value_propagation!