### PR TITLE
Remove stdlib flag for clang

### DIFF
--- a/ext/ruby-llvm-support/Rakefile
+++ b/ext/ruby-llvm-support/Rakefile
@@ -78,9 +78,8 @@ task :default => [SUPPORT_LIB, CONFIG_MOD]
 
 # -I/usr/lib/llvm-14/include/c++/v1/ is needed for CI
 file SUPPORT_LIB => %w(support.cpp) do |task|
-  clang_stdlib = CXX.match?(/^clang++/) ? "-stdlib=libc++" : ""
   sh "#{CXX} -O3 -shared #{task.prerequisites.join(' ')} -l#{llvm_lib_name} " \
-     "#{invoke_llvm_config('--cxxflags --ldflags')} -I/usr/lib/llvm-14/include/c++/v1/ -fPIC #{clang_stdlib} -o #{SUPPORT_LIB}"
+     "#{invoke_llvm_config('--cxxflags --ldflags')} -I/usr/lib/llvm-14/include/c++/v1/ -fPIC -o #{SUPPORT_LIB}"
 end
 
 LLVM_CONFIG_OPTS = [


### PR DESCRIPTION
The `-stdlib` flag broke the gem build for me on Ubuntu 23.04 with LLVM 16. I tried both with clang 15 and clang 16, i.e. `clang++` and `clang++-16`.

The build error prior to this commit was:

```
clang++-16 -O3 -shared support.cpp -lLLVM-16 -I/usr/lib/llvm-16/include -std=c++17
-fno-exceptions -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS
-L/usr/lib/llvm-16/lib -I/usr/lib/llvm-14/include/c++/v1/ -fPIC -stdlib=libc++ -o libRubyLLVMSupport-16.so
In file included from support.cpp:6:
In file included from /usr/lib/llvm-16/include/llvm/IR/Attributes.h:19:
In file included from /usr/lib/llvm-16/include/llvm/ADT/ArrayRef.h:12:
In file included from /usr/lib/llvm-16/include/llvm/ADT/Hashing.h:49:
In file included from /usr/lib/llvm-16/include/llvm/Support/SwapByteOrder.h:17:

/usr/lib/llvm-16/include/llvm/ADT/bit.h:18:10: fatal error: 'cstdint' file not found
#include <cstdint>
         ^~~~~~~~~
1 error generated.
rake aborted!

Command failed with status (1): [clang++-16 -O3 -shared support.cpp -lLLVM-...]
```