### PR TITLE
Fix GenericValue.from_b

### DIFF
--- a/lib/llvm/execution_engine.rb
+++ b/lib/llvm/execution_engine.rb
@@ -280,7 +280,7 @@ module LLVM
 
     # Creates a GenericValue from a Ruby boolean.
     def self.from_b(b)
-      from_i(b ? 1 : 0, LLVM::Int1, false)
+      from_i(b ? 1 : 0, type: LLVM::Int1, signed: false)
     end
 
     # Creates a GenericValue from an FFI::Pointer pointing to some arbitrary value.

--- a/test/generic_value_test.rb
+++ b/test/generic_value_test.rb
@@ -21,4 +21,9 @@ class GenericValueTestCase < Minitest::Test
     assert_in_delta 2.2, LLVM::GenericValue.from_d(2.2).to_f(LLVM::Double), 1e-6
   end
 
+  def test_from_bool
+    assert_equal true, LLVM::GenericValue.from_b(true).to_b
+    assert_equal false, LLVM::GenericValue.from_b(false).to_b
+  end
+
 end


### PR DESCRIPTION
The method signature for `from_i` changed in 3bb2308 but there was no unit test for `from_b` which calls `from_i`..