### PR TITLE
Fix targets and target tests for Xtensa

### DIFF
--- a/lib/llvm/target.rb
+++ b/lib/llvm/target.rb
@@ -37,19 +37,15 @@ module LLVM
     def self.init(target, asm_printer = false)
       target_module = TargetModule.dup
       target_module.module_eval do
-        attach_function :"initialize_target_info_#{target}",
-            :"LLVMInitialize#{target}TargetInfo", [], :void
-        attach_function :"initialize_target_#{target}",
-            :"LLVMInitialize#{target}Target", [], :void
-        attach_function :"initialize_target_#{target}_mc",
-            :"LLVMInitialize#{target}TargetMC", [], :void
+        attach_function :"initialize_target_info_#{target}", :"LLVMInitialize#{target}TargetInfo", [], :void
+        attach_function :"initialize_target_#{target}", :"LLVMInitialize#{target}Target", [], :void
+        attach_function :"initialize_target_#{target}_mc", :"LLVMInitialize#{target}TargetMC", [], :void
 
-        attach_function :"initialize_#{target}_asm_printer",
-            :"LLVMInitialize#{target}AsmPrinter", [], :void
-        safe_attach_function :"initialize_#{target}_asm_parser",
-            :"LLVMInitialize#{target}AsmParser", [], :void
-        safe_attach_function :"initialize_#{target}_disassembler",
-            :"LLVMInitialize#{target}Disassembler", [], :void
+        if asm_printer
+          attach_function(:"initialize_#{target}_asm_printer", :"LLVMInitialize#{target}AsmPrinter", [], :void)
+        end
+        safe_attach_function :"initialize_#{target}_asm_parser", :"LLVMInitialize#{target}AsmParser", [], :void
+        safe_attach_function :"initialize_#{target}_disassembler", :"LLVMInitialize#{target}Disassembler", [], :void
       end
 
       C.extend(target_module)

--- a/test/target_test.rb
+++ b/test/target_test.rb
@@ -30,10 +30,15 @@ class TargetTestCase < Minitest::Test
     'LoongArch' => %w[loongarch64 loongarch32],
   }.freeze
 
+  SKIP_ASM_PRINTER = ['Xtensa'].freeze
+
   LLVM::CONFIG::TARGETS_BUILT.each do |arch|
     define_method("test_init_#{arch}") do
       LLVM::Target.init(arch)
-      LLVM::Target.init(arch, true)
+
+      if !SKIP_ASM_PRINTER.include?(arch)
+        LLVM::Target.init(arch, true)
+      end
 
       check_targets = TARGET_CHECKS[arch] || [arch.downcase]
 


### PR DESCRIPTION
tests on ubuntu are failing due to addition of Xtensa target which is missing asm printer