### PR TITLE
Re-Enable CI for macos-12 and macos-13

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04]
+        os: [ubuntu-22.04, macos-12, macos-13]
         ruby: ['2.7', '3.0', '3.1', '3.2', '3.3']
     continue-on-error: ${{ endsWith(matrix.ruby, 'head') || matrix.ruby == 'debug' }}
     steps:


### PR DESCRIPTION
- [x] Brew LLVM-18 support 
    - https://formulae.brew.sh/formula/llvm 
    - https://github.com/Homebrew/homebrew-core/pull/165206