### PR TITLE
Handle large constant integers > 64 bit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased]
 
+### Changed
+- fix multiple integer issues above 64 bits
+
 ## [19.1.0] - 2024-09-25
 
 ### Changed

--- a/lib/llvm/core/value.rb
+++ b/lib/llvm/core/value.rb
@@ -627,11 +627,22 @@ module LLVM
       type.from_f(to_i.to_f)
     end
 
-    def to_i(signed = true)
+    private def to_i_i64(signed)
       if signed
         C.const_int_get_sext_value(self)
       else
         C.const_int_get_zext_value(self)
+      end
+    end
+
+    # const_int_get_sext_value const_int_get_zext_value only return long long, 64-bits
+    # beyond 64-bits parse the string value into a ruby integer
+    # TODO: overflow behavior is not the same on these arms, signed is ignored above 64-bits
+    def to_i(signed = true)
+      if type.width <= 64
+        to_i_i64(signed)
+      else
+        to_s.split.last.to_i
       end
     end
   end

--- a/test/integer_test.rb
+++ b/test/integer_test.rb
@@ -202,4 +202,57 @@ class IntegerTestCase < Minitest::Test
     assert_equal LLVM::Int8.from_i(-1), LLVM::Int8.all_ones
     assert_equal LLVM::Int8.from_i(-1).to_s, LLVM::Int8.all_ones.to_s
   end
+
+  def test_parse_poison
+    assert_equal "i8 poison", LLVM::Int8.parse("128").to_s
+  end
+
+  def test_to_i
+    max = (2**63) - 1
+    int = LLVM.i(64, max)
+    assert_equal max, int.to_i
+
+    int = LLVM.i(64, max + 1)
+    assert_predicate int, :poison?
+
+    int = LLVM.i(65, max)
+    assert_equal max, int.to_i
+
+    int = LLVM.i(65, max + 1)
+    assert_equal max + 1, int.to_i
+  end
+
+  def test_parse_larger_int
+    parsed = LLVM::Int256.parse("0x10000000000000000000000000000000000000000", 16)
+    assert_equal "i256 1461501637330902918203684832716283019655932542976", parsed.to_s
+    assert_equal 1_461_501_637_330_902_918_203_684_832_716_283_019_655_932_542_976, parsed.to_i
+
+    parsed = LLVM::Int256.parse("10000000000000000000000000000000000000000", 16)
+    assert_equal "i256 1461501637330902918203684832716283019655932542976", parsed.to_s
+    assert_equal 1_461_501_637_330_902_918_203_684_832_716_283_019_655_932_542_976, parsed.to_i
+  end
+
+  def test_new_larger_int
+    int = LLVM.i(256, 0x10000000000000000000000000000000000000000)
+    assert_equal "i256 1461501637330902918203684832716283019655932542976", int.to_s
+    assert_equal 1_461_501_637_330_902_918_203_684_832_716_283_019_655_932_542_976, int.to_i
+
+    int = LLVM.i(256, 1_461_501_637_330_902_918_203_684_832_716_283_019_655_932_542_976)
+    assert_equal "i256 1461501637330902918203684832716283019655932542976", int.to_s
+    assert_equal 1_461_501_637_330_902_918_203_684_832_716_283_019_655_932_542_976, int.to_i
+  end
+
+  def test_new_larger_int_string
+    int = LLVM.i(256, "0x10000000000000000000000000000000000000000")
+    assert_equal "i256 1461501637330902918203684832716283019655932542976", int.to_s
+    assert_equal 1_461_501_637_330_902_918_203_684_832_716_283_019_655_932_542_976, int.to_i
+
+    int = LLVM.i(256, "1_461_501_637_330_902_918_203_684_832_716_283_019_655_932_542_976")
+    assert_equal "i256 1461501637330902918203684832716283019655932542976", int.to_s
+    assert_equal 1_461_501_637_330_902_918_203_684_832_716_283_019_655_932_542_976, int.to_i
+
+    int = LLVM.i(256, "10000000000000000000000000000000000000000")
+    assert_equal "i256 10000000000000000000000000000000000000000", int.to_s
+    assert_equal 10_000_000_000_000_000_000_000_000_000_000_000_000_000, int.to_i
+  end
 end


### PR DESCRIPTION
Fix #262 

Ensure to_i works > 64 bit
Ensure parse works > 64 bit
Ensure "new" works > 64 bit