### PR TITLE
Modernize sorbet and RBS

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,8 @@ updates:
       interval: "daily"
     allow:
       - dependency-type: all
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -45,7 +45,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -6,10 +6,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: ruby/setup-ruby@v1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
         with:
-          ruby-version: '3.4'
+          ruby-version: '4.0'
           bundler-cache: true
       - run: bundle install
       - name: Rubocop

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -51,9 +51,9 @@ jobs:
           sudo ./llvm.sh 21
           # sudo apt-get install -y libpolly-21-dev
           echo "setup=true" >> "$GITHUB_OUTPUT"
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         if: steps.macos_setup.outputs.setup == 'true' || steps.ubuntu_setup.outputs.setup == 'true'
-      - uses: ruby/setup-ruby@v1
+      - uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
         if: steps.macos_setup.outputs.setup == 'true' || steps.ubuntu_setup.outputs.setup == 'true'
         with:
           ruby-version: ${{ matrix.ruby }}

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -12,8 +12,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, ubuntu-24.04, macos-13, macos-14, macos-15]
-        ruby: ['3.1', '3.2', '3.3', '3.4']
+        os: [ubuntu-22.04, ubuntu-24.04, ubuntu-26.04, macos-14, macos-15, macos-15-intel, macos-26, macos-26-intel]
+        ruby: ['3.3', '3.4', '4.0']
     continue-on-error: ${{ endsWith(matrix.ruby, 'head') || matrix.ruby == 'debug' }}
     steps:
       - name: Install LLVM on macos

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -6,10 +6,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: ruby/setup-ruby@v1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
         with:
-          ruby-version: '3.4'
+          ruby-version: '4.0'
           bundler-cache: true
       - name: Sorbet
         run: |

--- a/lib/llvm/core/attribute.rb
+++ b/lib/llvm/core/attribute.rb
@@ -34,7 +34,7 @@ module LLVM
       end
 
       # create enum attribute with optional value and context
-      #: (untyped, ?Integer, ?Context) -> Attribute?
+      #: (String | Symbol, ?Integer, ?Context) -> Attribute?
       def enum(kind, value = 0, context = Context.global)
         attr_id = attribute_id(kind)
         ptr = C.create_enum_attribute(context, attr_id, value)
@@ -42,7 +42,7 @@ module LLVM
       end
 
       # create string attribute with key and value
-      #: (untyped, untyped, ?Context) -> Attribute?
+      #: (String | Symbol, untyped, ?Context) -> Attribute?
       def string(key, value, context = Context.global)
         key = key.to_s
         value = value.to_s

--- a/lib/llvm/core/module.rb
+++ b/lib/llvm/core/module.rb
@@ -6,6 +6,7 @@ module LLVM
     include PointerIdentity
 
     # @private
+    #: (FFI::Pointer) -> LLVM::Module?
     def self.from_ptr(ptr)
       return if ptr.null?
       mod = allocate
@@ -25,7 +26,7 @@ module LLVM
       @ptr = nil
     end
 
-    #: -> LLVM::Module
+    #: -> LLVM::Module?
     def clone_module
       Module.from_ptr(C.clone_module(self))
     end
@@ -85,7 +86,7 @@ module LLVM
       end
 
       # Returns the Type with the given name (symbol or string).
-      #: (untyped) -> Type
+      #: (String | Symbol) -> Type
       def named(name)
         Type.from_ptr(C.get_type_by_name(@module, name.to_s))
       end
@@ -107,40 +108,46 @@ module LLVM
       end
 
       # Adds a GlobalVariable with the given type and name to the collection (symbol or string).
-      def add(ty, name)
+      #: (untyped, String | Symbol) ?{ (GlobalVariable) -> void } -> GlobalVariable
+      def add(ty, name, &)
         GlobalVariable.from_ptr(C.add_global(@module, LLVM::Type(ty), name.to_s)).tap do |gvar|
           yield gvar if block_given?
         end
       end
 
       # Returns the GlobalVariable with the given name (symbol or string).
-      #: (untyped) -> GlobalVariable
+      #: (String | Symbol) -> GlobalVariable?
       def named(name)
-        GlobalVariable.from_ptr(C.get_named_global(@module, name.to_s))
+        ptr = C.get_named_global(@module, name.to_s)
+        GlobalVariable.from_ptr(ptr) unless ptr.null?
       end
 
       # Returns the first GlobalVariable in the collection.
-      #: -> GlobalVariable
+      #: -> GlobalVariable?
       def first
-        GlobalVariable.from_ptr(C.get_first_global(@module))
+        ptr = C.get_first_global(@module)
+        GlobalVariable.from_ptr(ptr) unless ptr.null?
       end
 
       # Returns the last GlobalVariable in the collection.
-      #: -> GlobalVariable
+      #: -> GlobalVariable?
       def last
-        GlobalVariable.from_ptr(C.get_last_global(@module))
+        ptr = C.get_last_global(@module)
+        GlobalVariable.from_ptr(ptr) unless ptr.null?
       end
 
       # Returns the next GlobalVariable in the collection after global.
-      #: (GlobalVariable) -> GlobalVariable
+      #: (GlobalVariable) -> GlobalVariable?
       def next(global)
-        GlobalVariable.from_ptr(C.get_next_global(global))
+        ptr = C.get_next_global(global)
+        GlobalVariable.from_ptr(ptr) unless ptr.null?
       end
 
       # Returns the previous GlobalVariable in the collection before global.
-      #: (GlobalVariable) -> GlobalVariable
+      #: (GlobalVariable) -> GlobalVariable?
       def previous(global)
-        GlobalVariable.from_ptr(C.get_previous_global(global))
+        ptr = C.get_previous_global(global)
+        GlobalVariable.from_ptr(ptr) unless ptr.null?
       end
 
       # Deletes the GlobalVariable from the collection.
@@ -150,12 +157,13 @@ module LLVM
       end
 
       # Returns the GlobalVariable with a name equal to key (symbol or string) or at key (integer).
+      #: (String | Symbol | Integer) -> GlobalVariable?
       def [](key)
         case key
         when String, Symbol then named(key)
         when Integer then
           i = 0
-          g = first
+          g = first #: GlobalVariable?
           until i >= key || g.nil?
             g = self.next(g)
             i += 1
@@ -165,8 +173,10 @@ module LLVM
       end
 
       # Iterates through each GlobalVariable in the collection.
+      # @override
+      #: { (GlobalVariable) -> void } -> void
       def each(&)
-        g = first
+        g = first #: GlobalVariable?
         until g.nil?
           yield g
           g = self.next(g)
@@ -207,28 +217,38 @@ module LLVM
       end
 
       # Returns the Function with the given name (symbol or string).
+      #: (String | Symbol) -> Function?
       def named(name)
-        Function.from_ptr(C.get_named_function(@module, name.to_s))
+        ptr = C.get_named_function(@module, name.to_s)
+        Function.from_ptr(ptr) unless ptr.null?
       end
 
       # Returns the first Function in the collection.
+      #: -> Function?
       def first
-        Function.from_ptr(C.get_first_function(@module))
+        ptr = C.get_first_function(@module)
+        Function.from_ptr(ptr) unless ptr.null?
       end
 
       # Returns the last Function in the collection.
+      #: -> Function?
       def last
-        Function.from_ptr(C.get_last_function(@module))
+        ptr = C.get_last_function(@module)
+        Function.from_ptr(ptr) unless ptr.null?
       end
 
       # Returns the next Function in the collection after function.
+      #: (Function) -> Function?
       def next(function)
-        Function.from_ptr(C.get_next_function(function))
+        ptr = C.get_next_function(function)
+        Function.from_ptr(ptr) unless ptr.null?
       end
 
       # Returns the previous Function in the collection before function.
+      #: (Function) -> Function?
       def previous(function)
-        Function.from_ptr(C.get_previous_function(function))
+        ptr = C.get_previous_function(function)
+        Function.from_ptr(ptr) unless ptr.null?
       end
 
       # Deletes the Function from the collection.
@@ -237,12 +257,13 @@ module LLVM
       end
 
       # Returns the Function with a name equal to key (symbol or string) or at key (integer).
+      #: (String | Symbol | Integer) -> Function?
       def [](key)
         case key
         when String, Symbol then named(key)
         when Integer
           i = 0
-          f = first
+          f = first #: Function?
           until i >= key || f.nil?
             f = self.next(f)
             i += 1
@@ -252,8 +273,10 @@ module LLVM
       end
 
       # Iterates through each Function in the collection.
+      # @override
+      #: { (Function) -> void } -> void
       def each(&)
-        f = first
+        f = first #: Function?
         until f.nil?
           yield f
           f = self.next(f)

--- a/lib/llvm/core/type.rb
+++ b/lib/llvm/core/type.rb
@@ -6,29 +6,35 @@ module LLVM
     include PointerIdentity
 
     # @private
-    #: (untyped, ?kind: Symbol?) -> Type
+    #: (FFI::Pointer, ?kind: Symbol?) -> Type
     def self.from_ptr(ptr, kind: nil)
       raise ArgumentError if ptr.null?
       kind ||= C.get_type_kind(ptr)
-      ty = case kind
+      case kind
       when :integer
-        IntType.allocate
+        IntType.new(ptr, kind)
       when :float, :double
-        RealType.allocate
+        RealType.new(ptr, kind)
       when :function
-        FunctionType.allocate
+        FunctionType.new(ptr, kind)
       when :struct
-        StructType.allocate
+        StructType.new(ptr, kind)
       else
-        allocate
+        new(ptr, kind)
       end
-      ty.instance_variable_set(:@ptr, ptr)
-      ty.instance_variable_set(:@kind, kind)
-      ty
+    end
+
+    # @private
+    #: (FFI::Pointer, Symbol?) -> void
+    def initialize(ptr, kind)
+      raise ArgumentError if ptr.null?
+      @ptr = ptr
+      @kind = kind
     end
 
     # Returns a symbol representation of the types kind (ex. :pointer, :vector, :array.)
-    attr_reader :kind #: Symbol?
+    #: Symbol?
+    attr_reader :kind
 
     # Returns the size of the type.
     #: -> ConstantInt
@@ -191,12 +197,12 @@ module LLVM
       end
     end
 
-    #: (untyped) -> Type
+    #: (String | Symbol) -> Type
     def self.opaque_struct(name)
       from_ptr(C.struct_create_named(Context.global, name.to_s), kind: :struct)
     end
 
-    #: (untyped) -> Type?
+    #: (String | Symbol) -> Type?
     def self.named(name)
       from_ptr(C.get_type_by_name2(Context.global, name.to_s))
     end
@@ -354,7 +360,7 @@ module LLVM
     #: -> Array[Type?]
     def argument_types
       size = C.count_param_types(self)
-      result = [] #: Array[Type]
+      result = [] #: Array[FFI::Pointer]
       FFI::MemoryPointer.new(FFI.type_size(:pointer) * size) do |types_ptr|
         C.get_param_types(self, types_ptr)
         result = types_ptr.read_array_of_pointer(size)
@@ -417,7 +423,7 @@ module LLVM
   end
 
   # Shortcut to Type.pointer.
-  #: (?Type?) -> Type`
+  #: (?Type?) -> Type
   def Pointer(ty = nil)
     LLVM::Type.pointer(ty)
   end

--- a/lib/llvm/core/value.rb
+++ b/lib/llvm/core/value.rb
@@ -6,11 +6,16 @@ module LLVM
     include PointerIdentity
 
     # @private
+    #: (FFI::Pointer) -> instance
     def self.from_ptr(ptr)
-      return if ptr.null?
-      val = allocate
-      val.instance_variable_set(:@ptr, ptr)
-      val
+      new(ptr)
+    end
+
+    # @private
+    #: (FFI::Pointer) -> void
+    def initialize(ptr)
+      raise ArgumentError if ptr.null?
+      @ptr = ptr
     end
 
     def self.from_ptr_kind(ptr) # rubocop:disable Metrics/CyclomaticComplexity

--- a/lib/llvm/execution_engine.rb
+++ b/lib/llvm/execution_engine.rb
@@ -152,6 +152,7 @@ module LLVM
 
       # @param [String, Symbol] name function name
       # @return [Function]
+      #: (String | Symbol) -> Function?
       def named(name)
         out_fun = FFI::MemoryPointer.new(:pointer)
 
@@ -258,12 +259,16 @@ module LLVM
     end
 
     # Casts an FFI::Pointer pointing to a GenericValue to an instance.
-    #: (FFI::Pointer?) -> GenericValue?
+    #: (FFI::Pointer) -> GenericValue
     def self.from_ptr(ptr)
-      return if ptr.nil? || ptr.null?
-      val = allocate
-      val.instance_variable_set(:@ptr, ptr)
-      val
+      new(ptr)
+    end
+
+    # @private
+    #: (FFI::Pointer) -> void
+    def initialize(ptr)
+      raise ArgumentError if ptr.null?
+      @ptr = ptr #: FFI::Pointer?
     end
 
     #: -> void

--- a/lib/llvm/target.rb
+++ b/lib/llvm/target.rb
@@ -122,9 +122,14 @@ module LLVM
     # @private
     #: (FFI::Pointer) -> Target
     def self.from_ptr(ptr)
-      target = allocate
-      target.instance_variable_set :@ptr, ptr
-      target
+      new(ptr)
+    end
+
+    # @private
+    #: (FFI::Pointer) -> void
+    def initialize(ptr)
+      raise ArgumentError if ptr.null?
+      @ptr = ptr
     end
 
     # Returns the name of the target.
@@ -176,10 +181,16 @@ module LLVM
     include PointerIdentity
 
     # @private
+    #: (FFI::Pointer) -> TargetMachine
     def self.from_ptr(ptr)
-      target = allocate
-      target.instance_variable_set :@ptr, ptr
-      target
+      new(ptr)
+    end
+
+    # @private
+    #: (FFI::Pointer) -> void
+    def initialize(ptr)
+      raise ArgumentError if ptr.null?
+      @ptr = ptr #: FFI::Pointer?
     end
 
     # Destroys this instance of TargetMachine.
@@ -238,6 +249,7 @@ module LLVM
     end
 
     # @private
+    #: (FFI::Pointer) -> TargetDataLayout
     def self.from_ptr(ptr)
       target = allocate
       target.instance_variable_set :@ptr, ptr

--- a/sorbet/config
+++ b/sorbet/config
@@ -1,9 +1,10 @@
+--parser=prism
+--enable-experimental-rbs-comments
 --dir
 .
 --ignore=tmp/
 --ignore=vendor/
 --ignore=samples/
---enable-experimental-rbs-comments
 --suppress-error-code=7003
 --suppress-error-code=7019
 --suppress-error-code=7006

--- a/test/double_test.rb
+++ b/test/double_test.rb
@@ -91,12 +91,14 @@ class DoubleTestCase < Minitest::Test
     engine = LLVM::MCJITCompiler.new(mod)
 
     arg = 5.0
-    result = engine.run_function(mod.functions["test"], arg)
+    function = mod.functions["test"] #: as !nil
+    result = engine.run_function(function, arg)
     assert_equal arg + 1, result&.to_f(LLVM::Double)
 
     skip 'MCJIT cannot find external function sin'
 
-    assert actual = engine.run_function(mod.functions["sin"], 1.0)&.to_f(LLVM::Double)
+    sin_function = mod.functions["sin"] #: as !nil
+    assert actual = engine.run_function(sin_function, 1.0)&.to_f(LLVM::Double)
     assert_in_delta(Math.sin(1.0), actual, 1e-10)
   end
 end

--- a/test/generic_value_test.rb
+++ b/test/generic_value_test.rb
@@ -8,6 +8,16 @@ class GenericValueTestCase < Minitest::Test
     LLVM.init_jit
   end
 
+  def test_null_pointer_rejected
+    assert_raises(ArgumentError) do
+      LLVM::GenericValue.new(FFI::Pointer::NULL)
+    end
+
+    assert_raises(ArgumentError) do
+      LLVM::GenericValue.from_ptr(FFI::Pointer::NULL)
+    end
+  end
+
   def test_from_i
     assert_equal 2, LLVM::GenericValue.from_i(2).to_i
     assert_equal 2, LLVM::GenericValue.from_i(2.2).to_i

--- a/test/mcjit_test.rb
+++ b/test/mcjit_test.rb
@@ -47,7 +47,8 @@ class MCJITTestCase < Minitest::Test
     engine = LLVM::MCJITCompiler.new(main_mod, :opt_level => 0)
     engine.modules << create_square_function_module
 
-    result = engine.run_function(main_mod.functions['call_square'])
+    function = main_mod.functions['call_square'] #: as !nil
+    result = engine.run_function(function)
     assert_equal 25, result.to_i
   end
 

--- a/test/target_test.rb
+++ b/test/target_test.rb
@@ -11,6 +11,24 @@ class TargetTestCase < Minitest::Test
     LLVM::Target.init('X86', true)
   end
 
+  def test_null_pointer_rejected
+    assert_raises(ArgumentError) do
+      LLVM::Target.new(FFI::Pointer::NULL)
+    end
+
+    assert_raises(ArgumentError) do
+      LLVM::Target.from_ptr(FFI::Pointer::NULL)
+    end
+
+    assert_raises(ArgumentError) do
+      LLVM::TargetMachine.new(FFI::Pointer::NULL)
+    end
+
+    assert_raises(ArgumentError) do
+      LLVM::TargetMachine.from_ptr(FFI::Pointer::NULL)
+    end
+  end
+
   def test_init_native
     LLVM::Target.init_native
     LLVM::Target.init_native(true)

--- a/test/type_test.rb
+++ b/test/type_test.rb
@@ -14,6 +14,16 @@ class TypeTestCase < Minitest::Test
     assert_equal :void, pointee.kind
   end
 
+  def test_null_pointer_rejected
+    assert_raises(ArgumentError) do
+      LLVM::Type.new(FFI::Pointer::NULL, nil)
+    end
+
+    assert_raises(ArgumentError) do
+      LLVM::Type.from_ptr(FFI::Pointer::NULL)
+    end
+  end
+
   def test_element_type_unsupported
     assert_raises(ArgumentError) do
       LLVM.Void.element_type

--- a/test/value_test.rb
+++ b/test/value_test.rb
@@ -12,6 +12,16 @@ class ValueTestCase < Minitest::Test
     refute_predicate LLVM::Int32.from_i(1), :null?
   end
 
+  def test_null_pointer_rejected
+    assert_raises(ArgumentError) do
+      LLVM::Value.new(FFI::Pointer::NULL)
+    end
+
+    assert_raises(ArgumentError) do
+      LLVM::Value.from_ptr(FFI::Pointer::NULL)
+    end
+  end
+
   def test_undef
     assert_predicate LLVM::Int32.undef, :undef?
     refute_predicate LLVM::Int32.from_i(1), :undef?


### PR DESCRIPTION
1. Pointer wrappers get real constructors

Five classes built instances with allocate + instance_variable_set, which hid `@ptr` from Sorbet and left `.new` as a broken zero-arg method: `Type`, `Value`, `Target`, `TargetMachine`, `GenericValue`. Each now has initialize(ptr, …) that assigns directly, and from_ptr is a thin factory over it. Every constructor rejects a null pointer with `ArgumentError`, so an invalid pointer fails at construction rather than surfacing as a segfault later. New tests cover both `.new` and `.from_ptr`.

API note: Type.new, Value.new, Target.new, TargetMachine.new, and GenericValue.new previously accepted zero arguments and returned unusable objects. They now require a pointer. Nothing in lib/ or test/ called them, but a downstream subclass defining initialize and calling super() would break.

2. Nilability corrected

  Typing the factories exposed signatures that were wrong but invisible, because `from_ptr` returned `T.untyped`.

3. Signature tightening

  Signatures were tightened as a result of other changes.

4. CI
  
- `actions/checkout` and `ruby/setup-ruby` pinned to commit SHAs with version comments across all four workflows. 
- Dependabot gained a github-actions ecosystem entry, weekly, which will maintain those pins and comments. 
- The testing matrix moved to Ruby 3.3/3.4/4.0 with newer OS images