### PR TITLE
Fix memory leaking through strings needing `dispose` method

### DIFF
--- a/lib/llvm/core_ffi.rb
+++ b/lib/llvm/core_ffi.rb
@@ -2,6 +2,7 @@
 
 require 'ffi'
 require 'llvm/version'
+require 'llvm/owned_string'
 
 module LLVM::C
   extend FFI::Library
@@ -781,7 +782,7 @@ module LLVM::C
   # @param [String] message
   # @return [String]
   # @scope class
-  attach_function :create_message, :LLVMCreateMessage, [:string], :string
+  attach_function :create_message, :LLVMCreateMessage, [:string], LLVM::OwnedString
 
   # (Not documented)
   #
@@ -789,7 +790,7 @@ module LLVM::C
   # @param [String] message
   # @return [nil]
   # @scope class
-  attach_function :dispose_message, :LLVMDisposeMessage, [:string], :void
+  attach_function :dispose_message, :LLVMDisposeMessage, [:pointer], :void
 
   # @defgroup LLVMCCoreContext Contexts
   #
@@ -880,7 +881,7 @@ module LLVM::C
   # @param [FFI::Pointer(DiagnosticInfoRef)] di
   # @return [String]
   # @scope class
-  attach_function :get_diag_info_description, :LLVMGetDiagInfoDescription, [:pointer], :string
+  attach_function :get_diag_info_description, :LLVMGetDiagInfoDescription, [:pointer], LLVM::OwnedString
 
   # Return an enum LLVMDiagnosticSeverity.
   #
@@ -1030,7 +1031,7 @@ module LLVM::C
   # @param [FFI::Pointer(ModuleRef)] m
   # @return [String]
   # @scope class
-  attach_function :print_module_to_string, :LLVMPrintModuleToString, [:pointer], :string
+  attach_function :print_module_to_string, :LLVMPrintModuleToString, [:pointer], LLVM::OwnedString
 
   # Set inline assembly for a module.
   #
@@ -1222,7 +1223,7 @@ module LLVM::C
   # @param [FFI::Pointer(TypeRef)] val
   # @return [String]
   # @scope class
-  attach_function :print_type_to_string, :LLVMPrintTypeToString, [:pointer], :string
+  attach_function :print_type_to_string, :LLVMPrintTypeToString, [:pointer], LLVM::OwnedString
 
   # Obtain an integer type from a context with specified bit width.
   #
@@ -1759,7 +1760,7 @@ module LLVM::C
   # @param [FFI::Pointer(ValueRef)] val
   # @return [String]
   # @scope class
-  attach_function :print_value_to_string, :LLVMPrintValueToString, [:pointer], :string
+  attach_function :print_value_to_string, :LLVMPrintValueToString, [:pointer], LLVM::OwnedString
 
   # Replace all uses of a value with another one.
   #

--- a/lib/llvm/core_ffi_v2.rb
+++ b/lib/llvm/core_ffi_v2.rb
@@ -5,6 +5,11 @@ module LLVM
   module C
     attach_function :dispose_message, :LLVMDisposeMessage, [:pointer], :void
 
+    # Both disposers must take :pointer, not :string. With :string, FFI marshals
+    # the Ruby String into a temporary buffer and LLVM frees that instead of its
+    # own allocation, aborting with "munmap_chunk(): invalid pointer".
+    attach_function :dispose_error_message, :LLVMDisposeErrorMessage, [:pointer], :void
+
     # typedef unsigned LLVMAttributeIndex;
     typedef(:uint, :llvmattributeindex)
 

--- a/lib/llvm/execution_engine.rb
+++ b/lib/llvm/execution_engine.rb
@@ -19,18 +19,13 @@ module LLVM
     # @return [ExecutionEngine] JIT execution engine
     def initialize(mod, options)
       FFI::MemoryPointer.new(FFI.type_size(:pointer)) do |ptr|
-        error   = FFI::MemoryPointer.new(FFI.type_size(:pointer))
-        status  = create_execution_engine_for_module(ptr, mod, error, options)
-        errorp  = error.read_pointer
-        message = errorp.read_string unless errorp.null?
-
-        if status.zero?
-          @ptr = ptr.read_pointer
-        else
-          C.dispose_message(error)
-          error.autorelease = false
-          raise "Error creating JIT compiler: #{message}"
+        message = LLVM.with_message_output do |err|
+          create_execution_engine_for_module(ptr, mod, err, options)
         end
+
+        raise "Error creating JIT compiler: #{message}" if message
+
+        @ptr = ptr.read_pointer
       end
     end
 
@@ -123,22 +118,15 @@ module LLVM
       # @param [LLVM::Module] mod
       # @return [LLVM::Module] deleted module
       def delete(mod)
-        error   = FFI::MemoryPointer.new(:pointer)
         out_mod = FFI::MemoryPointer.new(:pointer)
 
-        status = C.remove_module(@engine, mod, out_mod, error)
-
-        if status.zero?
-          LLVM::Module.from_ptr(out_mod.read_pointer)
-        else
-          errorp  = error.read_pointer
-          message = errorp.read_string unless errorp.null?
-
-          C.dispose_message(error)
-          error.autorelease = false
-
-          raise "Error removing module: #{message}"
+        message = LLVM.with_message_output do |err|
+          C.remove_module(@engine, mod, out_mod, err)
         end
+
+        raise "Error removing module: #{message}" if message
+
+        LLVM::Module.from_ptr(out_mod.read_pointer)
       end
 
       alias_method :<<, :add

--- a/lib/llvm/lljit.rb
+++ b/lib/llvm/lljit.rb
@@ -98,9 +98,7 @@ module LLVM
                       [:pointer, :pointer, :pointer], :pointer
 
       # TODO: extract and combine with PassBuilder
-      attach_function(:get_error_message, :LLVMGetErrorMessage, [:pointer], :string)
-
-      attach_function(:dispose_error_message, :LLVMDisposeErrorMessage, [:string], :void)
+      attach_function(:get_error_message, :LLVMGetErrorMessage, [:pointer], LLVM::OwnedErrorString)
     end
   end
 end

--- a/lib/llvm/owned_string.rb
+++ b/lib/llvm/owned_string.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+# typed: true
+
+require 'ffi'
+
+module LLVM
+  # Intended for LLVM functions that return a caller owned string which requires
+  # freeing with `dispose_message` i.e. those declared `char *` rather than `const
+  # char *`. Reads the buffer into a Ruby String and releases it with LLVMDisposeMessage.
+  #
+  # This prevents memory leaks at the expense of a string copy and free following return
+  module OwnedString
+    extend FFI::DataConverter
+
+    native_type FFI::Type::POINTER
+
+    #: (FFI::Pointer, untyped) -> String?
+    def self.from_native(ptr, _ctx)
+      return if ptr.null?
+
+      begin
+        ptr.read_string
+      ensure
+        LLVM::C.dispose_message(ptr)
+      end
+    end
+  end
+
+  # As OwnedString, but for LLVMGetErrorMessage, which the LLVM headers require
+  # be freed with LLVMDisposeErrorMessage rather than LLVMDisposeMessage. The
+  # two are not interchangeable, so this cannot share OwnedString.
+  module OwnedErrorString
+    extend FFI::DataConverter
+
+    native_type FFI::Type::POINTER
+
+    #: (FFI::Pointer, untyped) -> String?
+    def self.from_native(ptr, _ctx)
+      return if ptr.null?
+
+      begin
+        ptr.read_string
+      ensure
+        LLVM::C.dispose_error_message(ptr)
+      end
+    end
+  end
+end

--- a/lib/llvm/pass_builder.rb
+++ b/lib/llvm/pass_builder.rb
@@ -631,11 +631,7 @@ module LLVM
 
       error = with_options { |options| C.run_passes(mod, pass_string, target, options) }
       if !error.null?
-        error_msg = C.get_error_message(error)
-        # TODO: clone then dispose of error_msg, currently produces "munmap_chunk(): invalid pointer"
-        # save_message = error_msg.clone
-        # C.dispose_error_message(error_msg)
-        raise ArgumentError, error_msg
+        raise ArgumentError, C.get_error_message(error)
       end
       self
     end
@@ -822,9 +818,7 @@ module LLVM
 
     attach_function :dispose_pass_builder_options, :LLVMDisposePassBuilderOptions, [:pointer], :void
 
-    attach_function(:get_error_message, :LLVMGetErrorMessage, [:pointer], :string)
-
-    attach_function(:dispose_error_message, :LLVMDisposeErrorMessage, [:string], :void)
+    attach_function(:get_error_message, :LLVMGetErrorMessage, [:pointer], LLVM::OwnedErrorString)
 
     attach_function(:set_inliner_threshold, :LLVMPassBuilderOptionsSetInlinerThreshold, [:pointer, :int], :void)
 

--- a/lib/llvm/support.rb
+++ b/lib/llvm/support.rb
@@ -29,7 +29,7 @@ module LLVM
           :LLVMInitializeNativeAsmPrinter, [], :void
 
       attach_function :get_enum_attribute_name_for_kind, :LLVMGetEnumAttributeNameForKind, [:uint], :string
-      attach_function :get_attribute_as_string, :LLVMGetAttributeAsString, [:pointer], :string
+      attach_function :get_attribute_as_string, :LLVMGetAttributeAsString, [:pointer], LLVM::OwnedString
     end
   end
 

--- a/lib/llvm/target.rb
+++ b/lib/llvm/target.rb
@@ -236,9 +236,8 @@ module LLVM
 
   # @private
   module C
-    # ffi_gen autodetects :string, which is too weak to be usable
-    # with LLVMDisposeMessage
-    attach_function :copy_string_rep_of_target_data, :LLVMCopyStringRepOfTargetData, [OpaqueTargetData], :pointer
+    # ffi_gen autodetects :string, which leaks the caller-owned buffer
+    attach_function :copy_string_rep_of_target_data, :LLVMCopyStringRepOfTargetData, [OpaqueTargetData], LLVM::OwnedString
   end
 
   class TargetDataLayout
@@ -274,11 +273,7 @@ module LLVM
     #
     # @return [String]
     def to_s
-      string_ptr = C.copy_string_rep_of_target_data(self)
-      string = string_ptr.read_string
-      C.dispose_message(string_ptr)
-
-      string
+      C.copy_string_rep_of_target_data(self)
     end
 
     # Returns the byte order of a target, either :big_endian or :little_endian.

--- a/lib/llvm/target_ffi.rb
+++ b/lib/llvm/target_ffi.rb
@@ -516,7 +516,7 @@ module LLVM::C
   # @param [OpaqueTargetMachine] t
   # @return [String]
   # @scope class
-  attach_function :get_target_machine_triple, :LLVMGetTargetMachineTriple, [OpaqueTargetMachine], :string
+  attach_function :get_target_machine_triple, :LLVMGetTargetMachineTriple, [OpaqueTargetMachine], LLVM::OwnedString
 
   # Returns the cpu used creating this target machine. See
   #   llvm::TargetMachine::getCPU. The result needs to be disposed with
@@ -526,7 +526,7 @@ module LLVM::C
   # @param [OpaqueTargetMachine] t
   # @return [String]
   # @scope class
-  attach_function :get_target_machine_cpu, :LLVMGetTargetMachineCPU, [OpaqueTargetMachine], :string
+  attach_function :get_target_machine_cpu, :LLVMGetTargetMachineCPU, [OpaqueTargetMachine], LLVM::OwnedString
 
   # Returns the feature string used creating this target machine. See
   #   llvm::TargetMachine::getFeatureString. The result needs to be disposed with
@@ -536,7 +536,7 @@ module LLVM::C
   # @param [OpaqueTargetMachine] t
   # @return [String]
   # @scope class
-  attach_function :get_target_machine_feature_string, :LLVMGetTargetMachineFeatureString, [OpaqueTargetMachine], :string
+  attach_function :get_target_machine_feature_string, :LLVMGetTargetMachineFeatureString, [OpaqueTargetMachine], LLVM::OwnedString
 
   # Create a DataLayout based on the targetMachine.
   #
@@ -587,7 +587,7 @@ module LLVM::C
   # @method get_default_target_triple()
   # @return [String]
   # @scope class
-  attach_function :get_default_target_triple, :LLVMGetDefaultTargetTriple, [], :string
+  attach_function :get_default_target_triple, :LLVMGetDefaultTargetTriple, [], LLVM::OwnedString
 
   # Adds the target-specific analysis passes to the pass manager.
   #


### PR DESCRIPTION
`OwnedString` and `OwnedErrorString` use `FFI::DataConverter` to read a `char*` into a Ruby string and immediately dispose of it