### PR TITLE
Route `dump` through Ruby for Module, Value, Type

### DIFF
--- a/ext/ruby-llvm-support/support.cpp
+++ b/ext/ruby-llvm-support/support.cpp
@@ -3,7 +3,23 @@
  */
 
 #include <llvm/Support/TargetSelect.h>
+#include <llvm/Support/raw_ostream.h>
 #include <llvm/IR/Attributes.h>
+#include <llvm/IR/Module.h>
+#include <llvm/IR/Value.h>
+#include <llvm/IR/Type.h>
+#include <llvm-c/Core.h>
+#include <string>
+
+// Allocates a caller-owned copy of s, to be released with LLVMDisposeMessage.
+//
+// Uses LLVMCreateMessage rather than strdup so the allocation happens inside
+// LLVM's own module, pairing with the free() that LLVMDisposeMessage performs
+// there. Every string this file hands back is declared `char *` (not `const
+// char *`) and goes through here, so ownership is stated in one place.
+static char* owned_message(const std::string &s) {
+  return LLVMCreateMessage(s.c_str());
+}
 
 extern "C" {
   void LLVMInitializeAllTargetInfos() {
@@ -40,10 +56,65 @@ extern "C" {
 
   // std::string Attribute::getAsString(bool InAttrGrp = false) const
   // https://llvm.org/doxygen/classllvm_1_1Attribute.html
-  // string must be disposed with LLVMDisposeMessage
-  const char* LLVMGetAttributeAsString(LLVMAttributeRef A) {
-    auto S = llvm::unwrap(A).getAsString();
-    return strdup(S.c_str());
+  char* LLVMGetAttributeAsString(LLVMAttributeRef A) {
+    return owned_message(llvm::unwrap(A).getAsString());
+  }
+
+  // void Type::print(raw_ostream &O, bool IsForDebug = false,
+  //                  bool NoDetails = false) const
+  // https://llvm.org/doxygen/classllvm_1_1Type.html
+  //
+  // As LLVMPrintTypeToString, but with IsForDebug=true, matching what
+  // LLVMDumpType writes to stderr. As of LLVM 21 this renders identically to
+  // IsForDebug=false for every type kind; it exists so the API matches Module
+  // and Value, and so a future divergence is picked up rather than missed.
+  // String must be disposed with LLVMDisposeMessage.
+  char* LLVMPrintTypeToStringDebug(LLVMTypeRef Ty) {
+    std::string buf;
+    llvm::raw_string_ostream os(buf);
+    if (llvm::unwrap(Ty))
+      llvm::unwrap(Ty)->print(os, /*IsForDebug=*/true);
+    else
+      os << "Printing <null> Type";
+    os.flush();
+    return owned_message(buf);
+  }
+
+  // void Value::print(raw_ostream &O, bool IsForDebug = false) const
+  // https://llvm.org/doxygen/classllvm_1_1Value.html
+  //
+  // As LLVMPrintValueToString, but with IsForDebug=true, matching what
+  // LLVMDumpValue writes to stderr. Only affects function declarations, whose
+  // parameters LLVMPrintValueToString omits.
+  // String must be disposed with LLVMDisposeMessage.
+  char* LLVMPrintValueToStringDebug(LLVMValueRef V) {
+    std::string buf;
+    llvm::raw_string_ostream os(buf);
+    if (llvm::unwrap(V))
+      llvm::unwrap(V)->print(os, /*IsForDebug=*/true);
+    else
+      os << "Printing <null> Value";
+    os.flush();
+    return owned_message(buf);
+  }
+
+  // void Module::print(raw_ostream &OS, AssemblyAnnotationWriter *AAW,
+  //                    bool ShouldPreserveUseListOrder = false,
+  //                    bool IsForDebug = false) const
+  // https://llvm.org/doxygen/classllvm_1_1Module.html
+  //
+  // As LLVMPrintModuleToString, but with IsForDebug=true, matching what
+  // LLVMDumpModule writes to stderr. Only affects declarations, whose
+  // parameters LLVMPrintModuleToString omits.
+  // String must be disposed with LLVMDisposeMessage.
+  char* LLVMPrintModuleToStringDebug(LLVMModuleRef M) {
+    std::string buf;
+    llvm::raw_string_ostream os(buf);
+    llvm::unwrap(M)->print(os, nullptr,
+                           /*ShouldPreserveUseListOrder=*/false,
+                           /*IsForDebug=*/true);
+    os.flush();
+    return owned_message(buf);
   }
 }
 

--- a/lib/llvm/core/module.rb
+++ b/lib/llvm/core/module.rb
@@ -285,13 +285,27 @@ module LLVM
     end
 
     # Returns the LLVM IR of the module as a string.
+    #: -> String
     def to_s
       C.print_module_to_string(self)
     end
 
+    # Returns the LLVM IR of the module as #dump renders it (LLVM's IsForDebug),
+    # which differs from #to_s only for declarations, whose parameters #to_s
+    # omits.
+    #: -> String
+    def debug_s
+      Support::C.print_module_to_string_debug(self)
+    end
+
     # Print the module's IR to the standard error.
+    #
+    # Equivalent to LLVMDumpModule, but written through Ruby's $stderr rather
+    # than LLVM's errs(), so reassigning $stderr captures it.
+    #: -> void
     def dump
-      C.dump_module(self)
+      # not warn: warn is silenced by -W0, and an explicit dump must always print
+      $stderr.puts(debug_s) # rubocop:disable Style/StderrPuts
     end
   end
 end

--- a/lib/llvm/core/type.rb
+++ b/lib/llvm/core/type.rb
@@ -92,18 +92,29 @@ module LLVM
       Type.pointer(self, address_space: address_space)
     end
 
-    # Print the type's representation to stdout.
+    # Print the type's representation to the standard error.
+    #
+    # Renders as LLVMDumpType does, but written through Ruby's $stderr rather
+    # than LLVM's errs(), so reassigning $stderr captures it, and always ends
+    # with a newline where LLVMDumpType emits none.
     #: -> void
     def dump
-      # :nocov:
-      C.dump_type(self)
-      # :nocov:
+      # not warn: warn is silenced by -W0, and an explicit dump must always print
+      $stderr.puts(debug_s) # rubocop:disable Style/StderrPuts
     end
 
     # Build string of LLVM type representation.
     #: -> String
     def to_s
       C.print_type_to_string(self)
+    end
+
+    # Returns the type as #dump renders it (LLVM's IsForDebug). As of LLVM 21
+    # this is identical to #to_s for every type kind, unlike Module and Value
+    # where it changes how declarations render.
+    #: -> String
+    def debug_s
+      Support::C.print_type_to_string_debug(self)
     end
 
     #: -> bool

--- a/lib/llvm/core/value.rb
+++ b/lib/llvm/core/value.rb
@@ -107,15 +107,30 @@ module LLVM
       C.set_value_name(self, str)
     end
 
-    # Print the value's IR to stdout.
+    # Print the value's IR to the standard error.
+    #
+    # Renders as LLVMDumpValue does, but written through Ruby's $stderr rather
+    # than LLVM's errs(), so reassigning $stderr captures it. Always ends with a
+    # newline; LLVMDumpValue emits none for values whose IR lacks one, such as
+    # constants.
+    #: -> void
     def dump
-      # :nocov:
-      C.dump_value(self)
-      # :nocov:
+      # not warn: warn is silenced by -W0, and an explicit dump must always print
+      $stderr.puts(debug_s) # rubocop:disable Style/StderrPuts
     end
 
+    # Returns the value's IR as a string.
+    #: -> String
     def to_s
       C.print_value_to_string(self)
+    end
+
+    # Returns the value's IR as #dump renders it (LLVM's IsForDebug), which
+    # differs from #to_s only for function declarations, whose parameters #to_s
+    # omits.
+    #: -> String
+    def debug_s
+      Support::C.print_value_to_string_debug(self)
     end
 
     # Returns whether the value is constant.

--- a/lib/llvm/support.rb
+++ b/lib/llvm/support.rb
@@ -30,6 +30,9 @@ module LLVM
 
       attach_function :get_enum_attribute_name_for_kind, :LLVMGetEnumAttributeNameForKind, [:uint], :string
       attach_function :get_attribute_as_string, :LLVMGetAttributeAsString, [:pointer], LLVM::OwnedString
+      attach_function :print_module_to_string_debug, :LLVMPrintModuleToStringDebug, [:pointer], LLVM::OwnedString
+      attach_function :print_value_to_string_debug, :LLVMPrintValueToStringDebug, [:pointer], LLVM::OwnedString
+      attach_function :print_type_to_string_debug, :LLVMPrintTypeToStringDebug, [:pointer], LLVM::OwnedString
     end
   end
 

--- a/test/module_test.rb
+++ b/test/module_test.rb
@@ -21,6 +21,26 @@ class ModuleTestCase < Minitest::Test
     assert_equal 1, simple_function().to_i
   end
 
+  # #debug_s renders like #dump (IsForDebug=true), which differs from #to_s
+  # only for declarations: their parameters are printed, not just their types.
+  def test_debug_s
+    mod = LLVM::Module.new('m')
+    mod.functions.add('decl', [LLVM::Int32, LLVM::Int32], LLVM::Int32)
+
+    assert_includes mod.to_s, 'declare i32 @decl(i32, i32)'
+    assert_includes mod.debug_s, 'declare i32 @decl(i32 %0, i32 %1)'
+  end
+
+  # a definition renders identically either way
+  def test_debug_s_matches_to_s_for_definitions
+    mod = LLVM::Module.new('m')
+    mod.functions.add('defn', [LLVM::Int32], LLVM::Int32) do |fun, _p0|
+      fun.basic_blocks.append('entry')
+    end
+
+    assert_equal mod.to_s, mod.debug_s
+  end
+
   def test_global_variable
     yielded = false #: bool
 
@@ -76,6 +96,23 @@ class ModuleTestCase < Minitest::Test
         $stderr.reopen(stderr_old)
       end
     end
+  end
+
+  # #dump goes through Ruby's $stderr, so reassigning the global captures it.
+  # LLVMDumpModule writes to LLVM's errs() on fd 2 and would not be captured.
+  def test_dump_writes_to_ruby_stderr
+    mod = LLVM::Module.new('test_dump_capture')
+    buffer = StringIO.new
+
+    stderr_old = $stderr
+    begin
+      $stderr = buffer
+      mod.dump
+    ensure
+      $stderr = stderr_old
+    end
+
+    assert_match(/^; ModuleID = 'test_dump_capture'$/, buffer.string)
   end
 
   def test_module_properties

--- a/test/type_test.rb
+++ b/test/type_test.rb
@@ -24,6 +24,37 @@ class TypeTestCase < Minitest::Test
     end
   end
 
+  # LLVM's IsForDebug currently renders every type kind identically, unlike
+  # Module and Value where it changes declarations. Pinned so that a change in
+  # LLVM shows up here rather than silently.
+  def test_debug_s
+    types = [
+      LLVM::Int32.type, LLVM::Float.type, LLVM.Void, LLVM.Pointer,
+      LLVM::Type.array(LLVM::Int8, 4), LLVM::Type.vector(LLVM::Int8, 4),
+      LLVM::Type.struct([LLVM::Int32], false, 'S'), LLVM::Type.struct([LLVM::Int8], true),
+      LLVM::Type.opaque_struct('O'), LLVM::Type.function([LLVM::Int32], LLVM.Void),
+    ]
+
+    types.each do |type|
+      assert_equal type.to_s, type.debug_s, "#{type} differs under debug"
+    end
+
+    assert_equal 'i32', LLVM::Int32.type.debug_s
+  end
+
+  def test_dump_writes_to_ruby_stderr
+    buffer = StringIO.new
+    stderr_old = $stderr
+    begin
+      $stderr = buffer
+      LLVM::Int32.type.dump
+    ensure
+      $stderr = stderr_old
+    end
+
+    assert_equal "i32\n", buffer.string
+  end
+
   def test_element_type_unsupported
     assert_raises(ArgumentError) do
       LLVM.Void.element_type

--- a/test/value_test.rb
+++ b/test/value_test.rb
@@ -22,6 +22,28 @@ class ValueTestCase < Minitest::Test
     end
   end
 
+  # As with Module, IsForDebug only changes how declarations render.
+  def test_debug_s
+    mod = LLVM::Module.new('m')
+    decl = mod.functions.add('decl', [LLVM::Int32, LLVM::Int32], LLVM::Int32)
+
+    assert_equal 'declare i32 @decl(i32, i32)', decl.to_s.chomp
+    assert_equal 'declare i32 @decl(i32 %0, i32 %1)', decl.debug_s.chomp
+  end
+
+  def test_dump_writes_to_ruby_stderr
+    buffer = StringIO.new
+    stderr_old = $stderr
+    begin
+      $stderr = buffer
+      LLVM::Int32.from_i(7).dump
+    ensure
+      $stderr = stderr_old
+    end
+
+    assert_equal "i32 7\n", buffer.string
+  end
+
   def test_undef
     assert_predicate LLVM::Int32.undef, :undef?
     refute_predicate LLVM::Int32.from_i(1), :undef?


### PR DESCRIPTION
- add debug_s for these types which call c++ shims for getting the debugging string output